### PR TITLE
Add Beehiiv embed support for /news/newsletters signup

### DIFF
--- a/wp-content/themes/wp-starter/template-parts/page-blog.twig
+++ b/wp-content/themes/wp-starter/template-parts/page-blog.twig
@@ -6,7 +6,11 @@
 	<div class="container px-6 category-archive md:px-12">
 		{% include 'breadcrumbs.twig' with { 'page': page } %}
 		<div class="space-y-10 lg:space-y-12">
-			{{ post.content }}
+			{% if newsletter_signup_html %}
+				{{ newsletter_signup_html|raw }}
+			{% else %}
+				{{ post.content }}
+			{% endif %}
 
 			{% if posts %}
 

--- a/wp-content/themes/wp-starter/tpl-blog-newsletters.php
+++ b/wp-content/themes/wp-starter/tpl-blog-newsletters.php
@@ -1,14 +1,26 @@
 <?php
 /* Template Name: Newsletters Category Page */
+
 $context = Timber::context();
 $context['post'] = Timber::get_post();
 $context['title'] = get_the_title();
 
-// Get all posts from the "blog" category
+// Pagination (ensure $paged is defined)
+$paged = get_query_var('paged') ? (int) get_query_var('paged') : 1;
+
+// Optional: allow an embed (e.g., Beehiiv) to be configured via ACF.
+// Field can exist either on the page itself or as an ACF "Options" field.
+$context['newsletter_signup_html'] = (
+  function_exists('get_field')
+    ? (get_field('newsletter_signup_html', $context['post']->ID) ?: get_field('newsletter_signup_html', 'option'))
+    : null
+);
+
+// Get all posts from the "newsletters" category
 $context['posts'] = Timber::get_posts([
-  'post_type' => 'post',
-  'category_name' => 'newsletters',
-  'posts_per_page' => 9, // or specify a number like 10
+  'post_type'      => 'post',
+  'category_name'  => 'newsletters',
+  'posts_per_page' => 9,
   'paged'          => $paged,
 ]);
 


### PR DESCRIPTION
## Why
The /news/newsletters page currently embeds a Mailchimp signup form (list-manage.com). We want new signups to go to Beehiiv so Beehiiv automations trigger.

## What
- Adds optional `newsletter_signup_html` context to the Newsletters template (read from ACF field `newsletter_signup_html` on the page or in ACF Options).
- Updates the blog page template to render `newsletter_signup_html` (raw) when present; otherwise falls back to existing `post.content`.
- Fixes an undefined `$paged` variable in `tpl-blog-newsletters.php`.

## How to use (after deploy)
1. Create an ACF field named `newsletter_signup_html` (WYSIWYG/Text) either on the Newsletter page or in Options.
2. Paste the Beehiiv embed HTML snippet there.

## Notes
This PR intentionally does not hardcode the Beehiiv snippet or API key; it just enables configuring the embed safely in WP admin.

## Source links
- https://entethalliance.org/news/newsletters/ (current signup page)
- https://eeamembershub.beehiiv.com/subscribe (Beehiiv subscribe landing)

## HTML snippets (for WP admin)

### A) Quick fix (no Beehiiv embed needed): link/button to Beehiiv subscribe page
If you want the simplest possible change (still adds subscribers to Beehiiv and triggers workflows), replace the Mailchimp embed in the page content with:

```html
<div class="core-block">

<h2 class="wp-block-heading">Subscribe to EEA Newsletter</h2>
</div>
<div class="core-block">

<p>Subscribe via our Beehiiv newsletter:</p>
<p><a class="btn-primary" href="https://eeamembershub.beehiiv.com/subscribe" target="_blank" rel="noopener">Subscribe</a></p>
</div>
```

### B) Preferred: embedded Beehiiv form
After this PR is deployed, set ACF field `newsletter_signup_html` (page-level or Options) to the Beehiiv embed HTML snippet generated in Beehiiv.

This PR will render `newsletter_signup_html` when present; otherwise it falls back to existing `post.content`.
