### PR TITLE
Release: merge develop to main

### DIFF
--- a/wp-content/themes/wp-starter/assets/css/blocks/navigation.css
+++ b/wp-content/themes/wp-starter/assets/css/blocks/navigation.css
@@ -90,10 +90,8 @@
 
 @media (min-width: 1024px) {
   .sub-menu {
-    @apply overflow-hidden max-h-0 absolute left-0 top-full mt-2 py-2 transition-all duration-300 whitespace-nowrap;
-  }
-  .sub-menu::after {
-    @apply content-[''] block absolute inset-0 -z-10 rounded-xl backdrop-blur-md bg-black/60;
+    @apply overflow-hidden max-h-0 absolute left-0 transition-all duration-300 whitespace-nowrap rounded-xl backdrop-blur-md bg-black/60;
+    top: calc(100% + 8px);
   }
 }
 

--- a/wp-content/themes/wp-starter/assets/css/blocks/navigation.css
+++ b/wp-content/themes/wp-starter/assets/css/blocks/navigation.css
@@ -31,7 +31,7 @@
 
 @media (min-width: 1024px) {
   .main-menu {
-    @apply flex px-6 py-3 rounded-xl space-y-0 items-center pr-0 gap-x-2;
+    @apply flex px-6 py-3 rounded-xl space-y-0 items-center pr-0;
   }
   /* .main-menu::before {
     @apply content-[''] block absolute -z-10 left-0 right-0 bottom-0 top-0 backdrop-blur-md rounded-xl;
@@ -74,13 +74,13 @@
 @media (min-width: 1024px) {
   .menu-item.current-menu-item > div > a,
   .sub-menu .menu-item.current-menu-item > a {
-    @apply opacity-100 bg-[#171717] no-underline;
+    @apply opacity-100 bg-white/10 no-underline;
   }
 }
 
 @media (min-width: 1024px) {
-  .menu-item:hover a {
-    @apply bg-[#171717] opacity-100;
+  .menu-item:hover > div > a {
+    @apply bg-white/10 opacity-100;
   }
 }
 
@@ -90,7 +90,10 @@
 
 @media (min-width: 1024px) {
   .sub-menu {
-    @apply overflow-hidden max-h-0 absolute left-0 top-full pt-3  transition-all duration-300  whitespace-nowrap;
+    @apply overflow-hidden max-h-0 absolute left-0 top-full mt-2 py-2 transition-all duration-300 whitespace-nowrap;
+  }
+  .sub-menu::after {
+    @apply content-[''] block absolute inset-0 -z-10 rounded-xl backdrop-blur-md bg-black/60;
   }
 }
 
@@ -124,7 +127,7 @@
 
 @media (min-width: 1024px) {
   .sub-menu .menu-item a {
-    @apply text-base text-[14px] p-0 bg-[#171717] px-5 py-2.5 w-full no-underline;
+    @apply text-base text-[14px] p-0 bg-transparent px-5 py-2.5 w-full no-underline;
   }
   .sub-menu .menu-item a:hover,
   .sub-menu .current-menu-item a {
@@ -178,6 +181,10 @@
 
 .menu-btn-black a {
   @apply rounded-full inline-block bg-black border   py-2 px-5 border-white whitespace-nowrap !py-2 no-underline;
+}
+
+.menu-btn-white a {
+  @apply rounded-full inline-block bg-white text-black border border-white py-2 px-5 whitespace-nowrap !py-2 font-semibold no-underline;
 }
 @media (min-width: 1024px) {
   .menu-btn-gray a,

--- a/wp-content/themes/wp-starter/assets/css/blocks/navigation.css
+++ b/wp-content/themes/wp-starter/assets/css/blocks/navigation.css
@@ -112,7 +112,7 @@
 
 @media (min-width: 1024px) {
   .sub-menu .menu-item {
-    @apply p-0 mb-3;
+    @apply p-0 mb-0;
   }
 }
 @media (min-width: 1024px) {
@@ -127,7 +127,7 @@
 
 @media (min-width: 1024px) {
   .sub-menu .menu-item a {
-    @apply text-base text-[14px] p-0 bg-transparent px-5 py-2.5 w-full no-underline;
+    @apply text-base text-[14px] p-0 bg-transparent px-5 py-1.5 w-full no-underline;
   }
   .sub-menu .menu-item a:hover,
   .sub-menu .current-menu-item a {
@@ -136,8 +136,11 @@
 }
 
 @media (min-width: 1024px) {
+  .sub-menu .menu-item:first-child a {
+    @apply pt-2;
+  }
   .sub-menu .menu-item:last-child a {
-    @apply mb-1.5;
+    @apply pb-2;
   }
 }
 
@@ -171,7 +174,8 @@
 }
 
 .menu-btn-gray,
-.menu-btn-black {
+.menu-btn-black,
+.menu-btn-white {
   @apply border-0 pb-0 ml-4;
 }
 
@@ -184,7 +188,18 @@
 }
 
 .menu-btn-white a {
-  @apply rounded-full inline-block bg-white text-black border border-white py-2 px-5 whitespace-nowrap !py-2 font-semibold no-underline;
+  @apply rounded-full inline-block bg-white text-black border border-white py-2 px-5 whitespace-nowrap !py-2 font-semibold no-underline transition-all;
+}
+
+.menu-btn-white a:hover {
+  @apply bg-white/80 border-white/80;
+}
+
+@media (min-width: 1024px) {
+  .menu-btn-white:hover > div > a,
+  .menu-btn-white:hover a {
+    @apply bg-white/80 !important;
+  }
 }
 @media (min-width: 1024px) {
   .menu-btn-gray a,

--- a/wp-content/themes/wp-starter/template-parts/page-blog.twig
+++ b/wp-content/themes/wp-starter/template-parts/page-blog.twig
@@ -6,7 +6,11 @@
 	<div class="container px-6 category-archive md:px-12">
 		{% include 'breadcrumbs.twig' with { 'page': page } %}
 		<div class="space-y-10 lg:space-y-12">
-			{{ post.content }}
+			{% if newsletter_signup_html %}
+				{{ newsletter_signup_html|raw }}
+			{% else %}
+				{{ post.content }}
+			{% endif %}
 
 			{% if posts %}
 

--- a/wp-content/themes/wp-starter/tpl-blog-newsletters.php
+++ b/wp-content/themes/wp-starter/tpl-blog-newsletters.php
@@ -1,14 +1,26 @@
 <?php
 /* Template Name: Newsletters Category Page */
+
 $context = Timber::context();
 $context['post'] = Timber::get_post();
 $context['title'] = get_the_title();
 
-// Get all posts from the "blog" category
+// Pagination (ensure $paged is defined)
+$paged = get_query_var('paged') ? (int) get_query_var('paged') : 1;
+
+// Optional: allow an embed (e.g., Beehiiv) to be configured via ACF.
+// Field can exist either on the page itself or as an ACF "Options" field.
+$context['newsletter_signup_html'] = (
+  function_exists('get_field')
+    ? (get_field('newsletter_signup_html', $context['post']->ID) ?: get_field('newsletter_signup_html', 'option'))
+    : null
+);
+
+// Get all posts from the "newsletters" category
 $context['posts'] = Timber::get_posts([
-  'post_type' => 'post',
-  'category_name' => 'newsletters',
-  'posts_per_page' => 9, // or specify a number like 10
+  'post_type'      => 'post',
+  'category_name'  => 'newsletters',
+  'posts_per_page' => 9,
   'paged'          => $paged,
 ]);
 


### PR DESCRIPTION
## Summary
- Beehiiv embed support for /news/newsletters signup (#65)
- Navigation sub-menu fixes and hover improvements
- SEO: skip theme meta/OG when Rank Math is active
- Security headers via mu-plugin + deploy mu-plugins to WP Engine

## Post-deploy steps
- Create ACF field `newsletter_signup_html` in WP admin (page-level or Options)
- Paste Beehiiv embed HTML into that field

🤖 Generated with [Claude Code](https://claude.com/claude-code)