### PR TITLE
Remove staging Basic Auth credentials from public README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,9 @@ There are **two remote environments**, both on WP Engine:
 - **Deploy to Staging:** push (or merge) to `develop` → GitHub Actions builds the theme (including frontend assets) and deploys to staging.
 - **Deploy to Production:** merge `develop` into `main` and push → GitHub Actions builds and deploys to production.
 
-Staging is behind HTTP Basic Auth. Credentials:
-
-- **User:** `eeastage`
-- **Password:** `ethereum84874`
+Staging is behind HTTP Basic Auth. Credentials are **not** stored in this
+repository — ask a maintainer, or retrieve them from the WP Engine
+dashboard / the team's secret store.
 
 ---
 


### PR DESCRIPTION
@cristiano-c1 — flagging a security issue found while reviewing the site architecture for the redesign work.

The staging Basic Auth credentials are committed in plain text in this README, and this repository is public. Anyone on the internet can read them and browse https://eeastage.wpenginepowered.com/ — pre-release content, plugin/theme versions, and any test data on staging.

This PR removes them from the README, but that alone is not the fix, because they remain in git history:

1. **Rotate the staging Basic Auth password in the WP Engine dashboard (this is the actual fix — please do it first).**
2. Merge this PR so the README points people to the right place instead.
3. Consider making this repo private, and/or moving it into the EntEthAlliance GitHub org — production currently deploys from a repo outside the org's access controls.